### PR TITLE
Fix base64 encoding and decoding for s390x

### DIFF
--- a/turbob64_.h
+++ b/turbob64_.h
@@ -6,9 +6,13 @@ size_t tb64memcpy(const unsigned char *in, size_t inlen, unsigned char *out);  /
   #if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 #define BSWAP32(a) a 
 #define BSWAP64(a) a 
+#define BSWAP32_BE(a) bswap32(a)
+#define BSWAP64_BE(a) bswap64(a)
   #else
 #define BSWAP32(a) bswap32(a)
 #define BSWAP64(a) bswap64(a)
+#define BSWAP32_BE(a) a 
+#define BSWAP64_BE(a) a 
   #endif  
 
   #ifdef NB64CHECK
@@ -33,7 +37,7 @@ extern unsigned char tb64lutse[];
 
 #define ETAIL()\
   unsigned _l = (in+inlen) - ip;\
-  if(_l == 3) { unsigned _u = ip[0]<<24 | ip[1]<<16 | ip[2]<<8; stou32(op, SU32(_u)); op+=4; ip+=3; }\
+  if(_l == 3) { unsigned _u = ip[0]<<24 | ip[1]<<16 | ip[2]<<8; stou32(op, BSWAP32_BE(SU32(_u))); op+=4; ip+=3; }\
   else if(_l) { *op++ = tb64lutse[(ip[0]>>2)&0x3f];\
     if(_l == 2) *op++ = tb64lutse[(ip[0] & 0x3) << 4 | (ip[1] & 0xf0) >> 4],\
                 *op++ = tb64lutse[(ip[1] & 0xf) << 2];\

--- a/turbob64c.c
+++ b/turbob64c.c
@@ -47,8 +47,8 @@ size_t tb64enclen(size_t n) { return TB64ENCLEN(n); }
   unsigned _u1 = BSWAP32(ctou32(ip+_i_*6 + 3));\
   _u0 = SU32(_u0);\
   _u1 = SU32(_u1);\
-  stou32(op+_i_*8    , _u0);\
-  stou32(op+_i_*8 + 4, _u1);\
+  stou32(op+_i_*8    , BSWAP32_BE(_u0));\
+  stou32(op+_i_*8 + 4, BSWAP32_BE(_u1));\
 }
 
 unsigned char tb64lutse[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -71,7 +71,7 @@ size_t tb64senc(const unsigned char *in, size_t inlen, unsigned char *out) {
 	  #endif
     for(; op <= (out+outlen)-(16+OVS); op += 16, ip += (16/4)*3) { SI32(0); SI32(1); }
   }
-  for(; op < (out+outlen)-4; op += 4, ip += 3) { unsigned _u = BSWAP32(ctou32(ip)); stou32(op, SU32(_u)); }\
+  for(; op < (out+outlen)-4; op += 4, ip += 3) { unsigned _u = BSWAP32(ctou32(ip)); stou32(op, BSWAP32_BE(SU32(_u))); }\
   ETAIL(); 
   return outlen;
 }

--- a/turbob64d.c
+++ b/turbob64d.c
@@ -78,8 +78,8 @@ static const unsigned char lut[] = {
                           lut[                _u_>> 24 ])
 
 #define LI32C(_i_) {\
-  unsigned _u = ctou32(ip+_i_*8);   CHECK0(cu|= LU32C(_u)); _u = LU32(_u);\
-  unsigned _v = ctou32(ip+_i_*8+4); CHECK1(cu|= LU32C(_v)); _v = LU32(_v);\
+  unsigned _u = BSWAP32_BE(ctou32(ip+_i_*8));   CHECK0(cu|= LU32C(_u)); _u = LU32(_u);\
+  unsigned _v = BSWAP32_BE(ctou32(ip+_i_*8+4)); CHECK1(cu|= LU32C(_v)); _v = LU32(_v);\
   stou32(op+ _i_*6  , _u);\
   stou32(op+ _i_*6+3, _v);\
 }
@@ -88,8 +88,8 @@ static const unsigned char lut[] = {
 #define LI32(a) LI32C(a)
   #else
 #define LI32(_i_) { \
-  unsigned _u = ctou32(ip+_i_*8);    _u = LU32(_u);\
-  unsigned _v = ctou32(ip+_i_*8+4);  _v = LU32(_v);\
+  unsigned _u = BSWAP32_BE(ctou32(ip+_i_*8));    _u = LU32(_u);\
+  unsigned _v = BSWAP32_BE(ctou32(ip+_i_*8+4));  _v = LU32(_v);\
   stou32(op+ _i_*6  , _u);\
   stou32(op+ _i_*6+3, _v);\
 }
@@ -117,7 +117,7 @@ size_t tb64sdec(const unsigned char *in, size_t inlen, unsigned char *out) {
     if(   ip < (in+inlen)-( 8+OVS))                           { LI32(0); ip += 8; op += (8/4)*3; }
   }
   
-  for(; ip < (in+inlen)-4; ip += 4, op += 3) { unsigned u = ctou32(ip); cu |= LU32C(u); u = LU32(u); stou32(op, u); }
+  for(; ip < (in+inlen)-4; ip += 4, op += 3) { unsigned u = BSWAP32_BE(ctou32(ip)); cu |= LU32C(u); u = LU32(u); stou32(op, u); }
 
   unsigned u = 0, l = inlen - (ip-in);  
   if(l == 4) 															// last 4 bytes
@@ -128,7 +128,7 @@ size_t tb64sdec(const unsigned char *in, size_t inlen, unsigned char *out) {
 	}                                       
   unsigned char *up = (unsigned char *)&u;
   switch(l) {
-    case 4: u = ctou32(ip); cu |= LU32C(u); u = LU32(u);                   *op++ = up[0]; *op++ = up[1]; *op++ = up[2];                                             break; // 4->3 bytes
+    case 4: u = BSWAP32_BE(ctou32(ip)); cu |= LU32C(u); u = LU32(u);                   *op++ = up[0]; *op++ = up[1]; *op++ = up[2];                                             break; // 4->3 bytes
     case 3: u = BSWAP32(lut[ip[0]]<<26 | lut[ip[1]]<<20 | lut[ip[2]]<<14); *op++ = up[0]; *op++ = up[1];                cu |= lut[ip[0]] | lut[ip[1]] | lut[ip[2]]; break; // 3->2 bytes
     case 2: u = BSWAP32(lut[ip[0]]<<26 | lut[ip[1]]<<20);                  *op++ = up[0];                               cu |= lut[ip[0]] | lut[ip[1]];              break; // 2->1 byte
     case 1: u = BSWAP32(lut[ip[0]]);                                       *op++ = up[0];                               cu |= lut[ip[0]];                           break; // 1->1 byte

--- a/turbob64sse.c
+++ b/turbob64sse.c
@@ -473,9 +473,13 @@ char *cpustr(unsigned cpuisa) {
 }
 
 //---------------------------------------------------------------------------------
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+TB64FUNC _tb64e = tb64senc;
+TB64FUNC _tb64d = tb64sdec;
+#else
 TB64FUNC _tb64e = tb64xenc;
 TB64FUNC _tb64d = tb64xdec;
-
+#endif
 static int tb64set;
  
 void tb64ini(unsigned id, unsigned isshort) { 


### PR DESCRIPTION
On s390x, Turbo-Base64 encoding and decoding has Endian Issue. For Example,

```
select base64Encode('foo');
```
should return: `Zm9v`
but 0n s390x, it turns:  `v9mZ`

The fix is to reverse the byte order of 32 bit integer results before decoding and after encoding.
